### PR TITLE
[Fix] Add Windows support to uve-install.sh for CI and user install

### DIFF
--- a/uve-install.sh
+++ b/uve-install.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-# UVE Installer
 set -euo pipefail
 
 BASE_URL="https://github.com/iamshreeram/uve/releases/latest/download"
@@ -12,30 +11,44 @@ ARCH=$(uname -m)
 
 case $ARCH in
     x86_64) ARCH="amd64" ;;
-    arm64)  ARCH="arm64" ;;
-    *)      echo "Unsupported architecture"; exit 1 ;;
+    arm64 | aarch64) ARCH="arm64" ;;
+    *) echo "Unsupported architecture"; exit 1 ;;
 esac
 
-BIN_NAME="uve-${OS}-${ARCH}"
+BIN_PATH="${HOME}/.local/bin"
+mkdir -p "${BIN_PATH}"
 
-# Download appropriate binary
-echo "Downloading UVE for ${OS}-${ARCH}..."
 case $OS in
     linux|darwin)
+        BIN_NAME="uve-${OS}-${ARCH}"
+        echo "Downloading UVE for ${OS}-${ARCH}..."
         curl -L "${BASE_URL}/${BIN_NAME}.tar.gz" -o "${TEMP_DIR}/uve.tar.gz"
         tar -xzf "${TEMP_DIR}/uve.tar.gz" -C "${TEMP_DIR}"
-        BIN_PATH="${HOME}/.local/bin"
-        mkdir -p "${BIN_PATH}"
         mv "${TEMP_DIR}/${BIN_NAME}" "${BIN_PATH}/uve"
         chmod +x "${BIN_PATH}/uve"
         ;;
+    msys*|mingw*|cygwin*)
+        BIN_NAME="uve-windows-amd64.exe"
+        echo "Downloading UVE for windows-amd64..."
+        curl -L "${BASE_URL}/${BIN_NAME}.zip" -o "${TEMP_DIR}/uve.zip"
+        unzip -o "${TEMP_DIR}/uve.zip" -d "${TEMP_DIR}"
+        mv "${TEMP_DIR}/uve.exe" "${BIN_PATH}/uve.exe"
+        ;;
     *)
-        echo "Unsupported OS"; exit 1 ;;
+        echo "Unsupported OS: ${OS}"; exit 1 ;;
 esac
 
 # Initialize shell
 echo "Setting up shell integration..."
-"${BIN_PATH}/uve" init
+if [[ "$OS" == "linux" || "$OS" == "darwin" ]]; then
+    "${BIN_PATH}/uve" init
+else
+    "${BIN_PATH}/uve.exe" init
+fi
 
 echo "UVE installed successfully to ${BIN_PATH}"
-echo "Please restart your shell or run: source ~/.bashrc (or equivalent)"
+if [[ "$OS" == "linux" || "$OS" == "darwin" ]]; then
+    echo "Please restart your shell or run: source ~/.bashrc (or equivalent)"
+else
+    echo "Please restart your shell or run: Import-Module uve in PowerShell"
+fi


### PR DESCRIPTION
# [Fix] Add Windows support to uve-install.sh for CI and user install

## Background

Previously, `uve-install.sh` only supported Linux and macOS. On Windows, the script failed with "Unsupported OS". This led to installation failures on Windows runners (including GitHub Actions).

## Solution

- Added detection for msys/mingw/cygwin environments on Windows.
- Downloads and extracts the `.zip` file and places `uve.exe` in `~/.local/bin` on Windows.
- Executes the correct `init` command per platform.
- Ensures compatibility with Linux, macOS, and Windows (including CI).
- Outputs clear post-install instructions for each OS.

## Checklist

- [x] Cross-platform install tested.
- [x] CI can install on Windows runners.
- [x] User instructions are clear.

---

_Closes installation issues for Windows and unifies installation workflow._